### PR TITLE
Re-categorise 'update' & 'remove'

### DIFF
--- a/src/Tagged/Dict.elm
+++ b/src/Tagged/Dict.elm
@@ -16,12 +16,12 @@ Most functions here are simple wrappers to refine the types without modifying th
 
 # Build
 
-@docs empty, singleton, insert
+@docs empty, singleton, insert, update, remove
 
 
 # Query
 
-@docs update, remove, isEmpty, member, get, size
+@docs isEmpty, member, get, size
 
 
 # Lists


### PR DESCRIPTION
Super minor, but I noticed it and it seemed worth correcting at some point (unless you put them there for some reason I've missed.) Sorry I didn't do it in parallel to avoid a further release if you want it merged.

----
Commit message:

In the Core.Dict docs they appear in the Build section, not in the Query section.