### PR TITLE
Update to 0.19

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,0 +1,17 @@
+{
+    "type": "package",
+    "name": "joneshf/elm-tagged",
+    "summary": "A library to help with compile time verification",
+    "license": "BSD-3-Clause",
+    "version": "2.1.0",
+    "exposed-modules": [
+        "Tagged",
+        "Tagged.Dict",
+        "Tagged.Set"
+    ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/core": "1.0.0 <= v < 2.0.0"
+    },
+    "test-dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/joneshf/elm-tagged#readme",
   "devDependencies": {
-    "elm": "^0.18.0"
+    "elm": "0.19.0-bugfix2"
   }
 }


### PR DESCRIPTION
Via elm-upgrade. The elm-format changes have not been commited. I don't know if we want the 'bugfix2' in the package.json yet or if there is a better way to approach it.

I hope this is useful but it if you already had plans for how to go about this then feel free to close.

Thanks!